### PR TITLE
Fixed Fine-tune example code in ReadME

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ PYTHONPATH=./:$PYTHONPATH spark-submit spark_apps/prediction_cohorts/hf_readmiss
 
 ```console
 mkdir test_finetune_results;
-python -m cehrbert.runners.hf_cehrbert_finetuning_runner sample_configs/hf_cehrbert_finetuning_runner_config.yaml
+python -m cehrbert.runners.hf_cehrbert_finetune_runner sample_configs/hf_cehrbert_finetuning_runner_config.yaml
 ```
 
 ## Contact us


### PR DESCRIPTION
There was a small typo in the ReadME in the Fine-tune example code. The Script was addressed as _hf_cehrbert_finetuning_runner_, while it's actually called _hf_cehrbert_finetune_runner_.

Best wishes
Sami